### PR TITLE
Fix maintainer and prefixes

### DIFF
--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER Cloudsoft "brooklyn@cloudsoftcorp.com"
+MAINTAINER Andrew Kennedy "grkvlt@apache.org"
 
 # CONTAINER_SERVICE_VERSION_BELOW
 LABEL version="2.0.0-SNAPSHOT"

--- a/centos-7/docker-entrypoint.sh
+++ b/centos-7/docker-entrypoint.sh
@@ -9,8 +9,8 @@ echo "Starting CentOS 7 with SSH server"
 echo "=============================================="
 echo
 echo "User 'root' config"
-echo "CLOUDSOFT_ROOT_PASSWORD           ${CLOUDSOFT_ROOT_PASSWORD:+*****}"
-echo "CLOUDSOFT_ROOT_AUTHORIZED_KEY     ${CLOUDSOFT_ROOT_AUTHORIZED_KEY:0:20}"
+echo "BROOKLYN_ROOT_PASSWORD           ${BROOKLYN_ROOT_PASSWORD:+*****}"
+echo "BROOKLYN_ROOT_AUTHORIZED_KEY     ${BROOKLYN_ROOT_AUTHORIZED_KEY:0:20}"
 
 if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     echo
@@ -19,11 +19,11 @@ if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     touch /root/SSH_INITIALIZED_MARKER
 
     # set root password
-    if [ -n "$CLOUDSOFT_ROOT_PASSWORD" ]; then
+    if [ -n "$BROOKLYN_ROOT_PASSWORD" ]; then
         echo
         echo "Changing root's password" 
-        echo "root:$CLOUDSOFT_ROOT_PASSWORD" | chpasswd
-    elif [ -n "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" ]; then
+        echo "root:$BROOKLYN_ROOT_PASSWORD" | chpasswd
+    elif [ -n "$BROOKLYN_ROOT_AUTHORIZED_KEY" ]; then
         echo "Generating and changing root's password"
         PWPASS=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
         echo "root:$PWPASS" | chpasswd
@@ -32,12 +32,12 @@ if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     fi;
 
     # set root's authorized_keys
-    if [ -n "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" ]; then
+    if [ -n "$BROOKLYN_ROOT_AUTHORIZED_KEY" ]; then
         echo
         echo "Adding entry to /root/.ssh/authorized_keys"
         mkdir -p /root/.ssh
         chmod 700 /root/.ssh/
-        echo "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" | tee /root/.ssh/authorized_keys
+        echo "$BROOKLYN_ROOT_AUTHORIZED_KEY" | tee /root/.ssh/authorized_keys
         chmod 600 /root/.ssh/authorized_keys
     else
         echo "Not adding authorized ssh key"

--- a/ubuntu-14.04/Dockerfile
+++ b/ubuntu-14.04/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:14.04
-MAINTAINER Cloudsoft "brooklyn@cloudsoftcorp.com"
+MAINTAINER Andrew Kennedy "grkvlt@apache.org"
 
 # CONTAINER_SERVICE_VERSION_BELOW
 LABEL version="2.0.0-SNAPSHOT"

--- a/ubuntu-14.04/docker-entrypoint.sh
+++ b/ubuntu-14.04/docker-entrypoint.sh
@@ -9,8 +9,8 @@ echo "Starting Ubuntu 14.04 with SSH server"
 echo "=============================================="
 echo
 echo "User 'root' config"
-echo "CLOUDSOFT_ROOT_PASSWORD           ${CLOUDSOFT_ROOT_PASSWORD:+*****}"
-echo "CLOUDSOFT_ROOT_AUTHORIZED_KEY     ${CLOUDSOFT_ROOT_AUTHORIZED_KEY:0:20}"
+echo "BROOKLYN_ROOT_PASSWORD           ${BROOKLYN_ROOT_PASSWORD:+*****}"
+echo "BROOKLYN_ROOT_AUTHORIZED_KEY     ${BROOKLYN_ROOT_AUTHORIZED_KEY:0:20}"
 
 if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     echo
@@ -19,11 +19,11 @@ if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     touch /root/SSH_INITIALIZED_MARKER
 
     # set root password
-    if [ -n "$CLOUDSOFT_ROOT_PASSWORD" ]; then
+    if [ -n "$BROOKLYN_ROOT_PASSWORD" ]; then
         echo
         echo "Changing root's password" 
-        echo "root:$CLOUDSOFT_ROOT_PASSWORD" | chpasswd
-    elif [ -n "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" ]; then
+        echo "root:$BROOKLYN_ROOT_PASSWORD" | chpasswd
+    elif [ -n "$BROOKLYN_ROOT_AUTHORIZED_KEY" ]; then
         echo "Generating and changing root's password"
         PWPASS=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
         echo "root:$PWPASS" | chpasswd
@@ -32,12 +32,12 @@ if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     fi;
 
     # set root's authorized_keys
-    if [ -n "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" ]; then
+    if [ -n "$BROOKLYN_ROOT_AUTHORIZED_KEY" ]; then
         echo
         echo "Adding entry to /root/.ssh/authorized_keys"
         mkdir -p /root/.ssh
         chmod 700 /root/.ssh/
-        echo "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" | tee /root/.ssh/authorized_keys
+        echo "$BROOKLYN_ROOT_AUTHORIZED_KEY" | tee /root/.ssh/authorized_keys
         chmod 600 /root/.ssh/authorized_keys
     else
         echo "Not adding authorized ssh key"

--- a/ubuntu-16.04/Dockerfile
+++ b/ubuntu-16.04/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Cloudsoft "brooklyn@cloudsoftcorp.com"
+MAINTAINER Andrew Kennedy "grkvlt@apache.org"
 
 # CONTAINER_SERVICE_VERSION_BELOW
 LABEL version="2.0.0-SNAPSHOT"

--- a/ubuntu-16.04/docker-entrypoint.sh
+++ b/ubuntu-16.04/docker-entrypoint.sh
@@ -9,8 +9,8 @@ echo "Starting Ubuntu 16.04 with SSH server"
 echo "=============================================="
 echo
 echo "User 'root' config"
-echo "CLOUDSOFT_ROOT_PASSWORD           ${CLOUDSOFT_ROOT_PASSWORD:+*****}"
-echo "CLOUDSOFT_ROOT_AUTHORIZED_KEY     ${CLOUDSOFT_ROOT_AUTHORIZED_KEY:0:20}"
+echo "BROOKLYN_ROOT_PASSWORD           ${BROOKLYN_ROOT_PASSWORD:+*****}"
+echo "BROOKLYN_ROOT_AUTHORIZED_KEY     ${BROOKLYN_ROOT_AUTHORIZED_KEY:0:20}"
 
 if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     echo
@@ -19,11 +19,11 @@ if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     touch /root/SSH_INITIALIZED_MARKER
 
     # set root password
-    if [ -n "$CLOUDSOFT_ROOT_PASSWORD" ]; then
+    if [ -n "$BROOKLYN_ROOT_PASSWORD" ]; then
         echo
         echo "Changing root's password" 
-        echo "root:$CLOUDSOFT_ROOT_PASSWORD" | chpasswd
-    elif [ -n "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" ]; then
+        echo "root:$BROOKLYN_ROOT_PASSWORD" | chpasswd
+    elif [ -n "$BROOKLYN_ROOT_AUTHORIZED_KEY" ]; then
         echo "Generating and changing root's password"
         PWPASS=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
         echo "root:$PWPASS" | chpasswd
@@ -32,12 +32,12 @@ if [ ! -f "/root/SSH_INITIALIZED_MARKER" ]; then
     fi;
 
     # set root's authorized_keys
-    if [ -n "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" ]; then
+    if [ -n "$BROOKLYN_ROOT_AUTHORIZED_KEY" ]; then
         echo
         echo "Adding entry to /root/.ssh/authorized_keys"
         mkdir -p /root/.ssh
         chmod 700 /root/.ssh/
-        echo "$CLOUDSOFT_ROOT_AUTHORIZED_KEY" | tee /root/.ssh/authorized_keys
+        echo "$BROOKLYN_ROOT_AUTHORIZED_KEY" | tee /root/.ssh/authorized_keys
         chmod 600 /root/.ssh/authorized_keys
     else
         echo "Not adding authorized ssh key"


### PR DESCRIPTION
Change maintainer to ASF commiter account and set prefixes for environment variables to `BROOKLYN_`